### PR TITLE
chore: PR validation CI と README 追加(Sprint 1 polish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
-          cache: "npm"
+          node-version-file: package.json
+          cache: npm
       - run: npm ci
       - run: npm run typecheck
       - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,15 +18,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
-          cache: "npm"
+          node-version-file: package.json
+          cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -38,4 +38,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# crammr
+
+短期集中型・学習モチベーション維持アプリ。第一の利用ケースは簿記試験(2026-05-16)。
+
+- 公開 URL: https://sudame.net/crammr/
+- バックログ: https://github.com/users/sudame/projects/3
+- 開発ワークフロー: [docs/workflow/README.md](docs/workflow/README.md)
+
+## 開発
+
+```sh
+npm install
+npm run dev          # http://localhost:5173/crammr/
+npm run build
+npm run typecheck
+```
+
+main への push で GitHub Pages に自動デプロイされる。

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
Sprint 1 の Sprint Goal「URL で確認できる状態」をより堅牢にするためのリファインメント。

- `.github/workflows/ci.yml` で PR 時に typecheck + build を検証(壊れた PR の早期発見)
- `README.md` を追加(リポジトリ訪問者向けの最低限の入口)

## 確認したこと
- `npm run dev` が `http://localhost:5173/crammr/` で 200 を返すことを確認(DoD で claim 済みだったが未検証だった)

## 未対応
- HTTPS enforcement の API 切替は「証明書プロビジョニング中」で 404。実 URL は既に https で動作しているため後日再試行
- Issue #1 本文の URL 記述を `sudame.net/crammr/` に更新する作業は別途実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)